### PR TITLE
feat: add the multiplierForCLS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ export default {
       trackingID: 'UA-XXXXXXXX-X',
       // Event Category (optional) { string }, default 'Web Vitals'
       eventCategory: 'Some Category',
+      // Multiplier For CLS (optional) { number } default 1000
+      // Increase the multiplier for greater precision if needed.
+      multiplierForCLS: 10000,
       // Debug (optional) { number } default 0 
       debug: 1,
       disabled: false

--- a/module.js
+++ b/module.js
@@ -6,6 +6,9 @@ export default function (moduleOptions) {
   if (!options.eventCategory) {
     options.eventCategory = 'Web Vitals'
   }
+  if (!options.multiplierForCLS) {
+    options.multiplierForCLS = 1000
+  }
   if (!options.debug) {
     options.debug = 0
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-vitals",
-  "version": "0.1.6",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/plugin.js
+++ b/plugin.js
@@ -22,12 +22,14 @@ function encode (obj) {
 
 function sendToAnalytics (fullPath, metric) {
   const { name, delta, id, entries } = metric
+  const multiplier = parseInt('<%= options.multiplierForCLS %>')
   const opts = {
     ec: '<%= options.eventCategory %>',
     ea: name,
     el: id,
     // Google Analytics metrics must be integers, so the value is rounded.
-    ev: parseInt(delta),
+    // For CLS the value is multiplied by 1000 by default for greater precision
+    ev: Math.round(name === 'CLS' ? delta * multiplier : delta),
     dp: fullPath,
     ni: true
   }

--- a/plugin.js
+++ b/plugin.js
@@ -30,6 +30,7 @@ function sendToAnalytics (fullPath, metric) {
     // Google Analytics metrics must be integers, so the value is rounded.
     // For CLS the value is multiplied by 1000 by default for greater precision
     ev: Math.round(name === 'CLS' ? delta * multiplier : delta),
+    dh: document.location.hostname,
     dp: fullPath,
     ni: true
   }


### PR DESCRIPTION
- https://github.com/daliborgogic/nuxt-vitals/pull/9/commits/c59311f1c131cb8eeaa7c4f92f004a71bda604d2: Give developers the option to multiply a CLS value for greater precision, or CLS values are usually `0` even though the actual score is poor.
- https://github.com/daliborgogic/nuxt-vitals/pull/9/commits/475c9c3acb541dc9d921cbefcd0fd68300c2d2c3: Send the hostname parameter to prevent events from filtering out by GA View Filters.