### PR TITLE
docs: Add `log` provider to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 > Web Vitals: Essential module for a healthy [Nuxt.js](https://github.com/nuxt/nuxt.js)
 
-[Web Vitals](https://web.dev/vitals) is an initiative by Google to provide unified guidance for quality signals that are essential to delivering a great user experience on the web.
+[Web Vitals](https://web.dev/vitals) is an initiative by Google to provide unified guidance for quality signals that are essential to delivering a great user experience on the web.  
+This module will gather those metrics on each page view, and send them to a provider using either [`Navigator.sendBeacon()`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) or [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)
 
 ## Installation
 
@@ -45,7 +46,6 @@ export default {
 Create a GA property and get `trackingID`
 
 
-
 Either provide `GOOGLE_ANALYTICS_ID` environement variable or set inside `nuxt.config`:
 
 ```js
@@ -65,6 +65,19 @@ Behavior > Events > Overview > Event Category > Event Action
 
 Works without configuration
 
+### Basic logger
+
+Output metrics to the console insead of sending them to a remote provider 
+
+```js
+{
+  webVitals: {
+    provider: 'log',
+    debug: true, // debug enable metrics reporting on dev environments
+    disabled: false
+  }
+}
+```
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ export default {
 
 ### Google Analytics
 
-Create a GA property and get `trackingID`
+_Report WebVitals to GA_
 
+Create a GA property and get `trackingID`
 
 Either provide `GOOGLE_ANALYTICS_ID` environement variable or set inside `nuxt.config`:
 
@@ -63,9 +64,13 @@ Behavior > Events > Overview > Event Category > Event Action
 
 ### Vercel Analytics
 
+_Report WebVitals to Vercel_
+
 Works without configuration
 
 ### Basic logger
+
+_Report WebVitals to Console_
 
 Output metrics to the console insead of sending them to a remote provider 
 
@@ -78,6 +83,8 @@ Output metrics to the console insead of sending them to a remote provider
   }
 }
 ```
+
+:warning: this provider does not send WebVitals trough network, issues with navigator extensions can not be deteced with this method.
 
 ### License
 


### PR DESCRIPTION
Getting to know that this module can only be used to preview those metrics in development environment can involve people to use this great module.

I also added a small note about what this module does (related to #34)